### PR TITLE
Shelter Page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,7 @@ import SignUp from "./pages/signup";
 import SignIn from "./pages/signin.js";
 import Dashboard from "./pages/shelterDashboard.js";
 import Pet from "./pages/pet.js";
+import Shelter from "./pages/shelter.js";
 import FullScreenLoader from './components/FullScreenLoader';
 import Header from './components/Header/Header.js';
 import { ToastContainer } from 'react-toastify';
@@ -50,6 +51,12 @@ function AuthenticatedApp() {
                     <Route path="/sign-up" element={<SignUp user={user} />} />
                     <Route path="/sign-in" element={<SignIn user={user} />} />
                     <Route path="/pet" element={<Pet />} />
+                    <Route path="/shelter">
+                        <Route
+                            path=":id"
+                            element={<Shelter />}
+                        />
+                    </Route>
                     <Route
                         path="*"
                         element={<PageNotFound />}

--- a/src/pages/pet.js
+++ b/src/pages/pet.js
@@ -61,6 +61,10 @@ const Pet = () => {
                         style={{margin: "0.25rem", width: "95%"}} data-bs-toggle="modal" data-bs-target="#contactModal">
                             Contact Shelter
                         </button>
+                        <button type="button" className="btn btn-primary btn-lg btn-block" 
+                        style={{margin: "0.25rem", width: "95%"}} onClick={() => window.location.href = "/shelter/" + animal.shelterId}>
+                            View Shelter
+                        </button>
 
                         <div className="modal fade" id="contactModal" tabIndex="-1" aria-labelledby="contactModalLabel" aria-hidden="true">
                             <div className="modal-dialog">

--- a/src/pages/pet.js
+++ b/src/pages/pet.js
@@ -34,8 +34,14 @@ const Pet = () => {
     };
 
     useEffect(() => {
-        loadAnimals();
-    });
+        const getAnimals = async () => {
+            const item = doc(db, "animals", animal.id);
+            const itemSnap = await getDoc(item);
+            setAnimal(itemSnap.data());
+        };
+
+        getAnimals();
+    }, [animal.id]);
 
     const editAnimal = () => {
         setShowEditModal(true);

--- a/src/pages/shelter.js
+++ b/src/pages/shelter.js
@@ -1,0 +1,96 @@
+import React, { useState, useEffect } from "react";
+import { db } from "../firebaseConfig";
+import { collection, getDocs, query, where, limit } from "firebase/firestore";
+import { AnimalGalleryCard } from "../components/Cards";
+import { useParams } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
+
+const Shelter = () => {
+  const [animals, setAnimals] = useState([]);
+	const [shelter, setShelter] = useState({});
+	const navigate = useNavigate();
+
+	// If id not in the URL, redirect to 404
+	let { id } = useParams();
+	if (!id) navigate("/404");
+
+	useEffect(() => {
+		const loadShelter = async () => {
+			const q = query(
+				collection(db, "shelters"),
+				where("shelterId", "==", id),
+				limit(1)
+			);
+			const shelterSnapshot = await getDocs(q);
+			if (shelterSnapshot.empty) {
+				navigate("/404");
+			} else {
+				setShelter(shelterSnapshot.docs[0].data());
+			}
+		};
+
+		loadShelter();
+	}, [id, navigate]);
+
+	useEffect(() => {
+		const getAnimals = async () => {
+			const q = query(
+				collection(db, "animals"),
+				where("shelterId", "==", id),
+				where("status", "in", ["Available", "Pending"])
+			);
+			const animalSnapshot = await getDocs(q);
+			const animalList = animalSnapshot.docs.map((doc) => {
+				return { id: doc.id, ...doc.data() };
+			});
+			setAnimals(animalList);
+		};
+
+		getAnimals();
+	}, [id]);
+
+	return (
+		<div className="container mb-4">
+			<div className="container pt-2">
+				<h2>{shelter.name}</h2>
+				<p>
+					<strong>Address:</strong>&nbsp;{shelter.address}
+					<br />
+					<strong>Phone Number:</strong>&nbsp;{shelter.phone}
+				</p>
+				<h3 className="text-start pb-2">About</h3>
+				<p className="text-start">
+					Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla nec
+					purus feugiat, molestie ipsum et, consequat nibh. Etiam non elit dui.
+					Nulla nec purus feugiat, molestie ipsum et, consequat nibh. Etiam non
+					elit dui.
+				</p>
+				<h3 className="text-start pb-2">Animals</h3>
+				{animals.length === 0 && (
+					<p className="text-start">
+						This shelter has no animals available for adoption. Check back
+						later!
+					</p>
+				)}
+				<div className="row pb-4">
+					{animals.map((animal) => (
+						<div
+							className="col-6 col-md-4 col-lg-3 d-flex align-items-stretch my-2"
+							key={animal.id}
+						>
+							<AnimalGalleryCard
+								animal={animal}
+								callToAction=""
+								onClickAnimal={() =>
+									navigate("/pet", { state: { pet: animal } })
+								}
+							/>
+						</div>
+					))}
+				</div>
+			</div>
+		</div>
+	);
+};
+
+export default Shelter;


### PR DESCRIPTION
The first iteration of the Shelter page displays a list of a shelter's available or pending pets with the name, address, and phone number used to sign up for the account.

There's a placeholder for an about section, and I plan to add more ability for shelters to customize the page such as adding branding, colors, photos, etc.

Now when you open a pet's page, below the contact button, there is a button to view the other pets from the shelter. Each shelter has a unique URL based on their account ID like [`http://localhost:3000/shelter/SREzExJBQHe5bS0Fs8TGK7rdgGF2`](http://localhost:3000/shelter/SREzExJBQHe5bS0Fs8TGK7rdgGF2).

![Screenshot 2024-02-17 at 11 18 00 PM](https://github.com/senior-eng-project/Animal-Dating-App/assets/13807630/fde4974e-b6f1-4a1c-a132-50959c1284c9)
