### PR TITLE
Chat Name Bug Fix

### DIFF
--- a/src/components/Cards/ChatMessagesCard.js
+++ b/src/components/Cards/ChatMessagesCard.js
@@ -56,7 +56,7 @@ function ChatMessagesCard() {
     }, {});
 
     if (userId && !groupedMessages[userId]) {
-      groupedMessages[userId] = { messages: [], user: { id: userId, name: (userId || 'Anonymous User') } };
+      groupedMessages[userId] = { messages: [], user: { id: userId, name: (userName || 'Anonymous User') } };
     }
 
     setChats(groupedMessages);


### PR DESCRIPTION
I changed the variables yesterday to be more generic and better support user's who don't have a name set, but I accidentally changed the name value to the wrong variable.

This PR fixes that line to show the correct name when a user has a display name set.