### PR TITLE
Added Indicators

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -13,6 +13,20 @@ html, body {
   margin: auto;
 }
 
+.carousel-indicators button {
+  background-color: rgb(185, 185, 185);  
+  border: 1px solid rgb(173, 173, 173);
+  width: 20px;
+  height: 5px; 
+  margin: 0 5px;
+  border-radius: 2px;
+}
+
+.carousel-indicators button.active {
+  background-color: rgb(221, 237, 234);
+  border-color: rgb(143, 227, 213)
+}
+
 .filter-menu {
   position: fixed;
   top: 0;

--- a/src/components/Cards/AnimalCard.js
+++ b/src/components/Cards/AnimalCard.js
@@ -1,8 +1,13 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import FavoriteButton from "../FavoriteButton";
 
 const AnimalCard = ({ animal, animalId }) => {
     const [currentImageIndex, setCurrentImageIndex] = useState(0);
+    const [activeIndex, setActiveIndex] = useState(0);
+
+    useEffect(() => {
+        setActiveIndex(currentImageIndex);
+    }, [currentImageIndex]);
 
     const handlePrevClick = () => {
         setCurrentImageIndex((prevIndex) => (prevIndex === 0 ? animal.pictureUri.length - 1 : prevIndex - 1));
@@ -61,6 +66,17 @@ const AnimalCard = ({ animal, animalId }) => {
                                 <span className="carousel-control-next-icon" aria-hidden="true"></span>
                                 <span className="visually-hidden">Next</span>
                             </button>
+
+                            <div className="carousel-indicators">
+                                {animal.pictureUri.map((_, index) => (
+                                    <button
+                                        key={index}
+                                        type="button"
+                                        className={index === activeIndex ? "active" : ""}
+                                        aria-current={index === activeIndex ? "true" : "false"}
+                                    />
+                                ))}
+                            </div>
 
                             <div className="card-img-overlay d-flex" style={{ alignItems: 'flex-start', paddingTop: '0.5rem', paddingLeft: '0.5rem' }}>
                                 <div className={`text-white fw-semibold`} style={{ padding: '0.25rem 0.5rem', borderRadius: '0.25rem', fontSize: '0.8rem', backgroundColor: statusColor }}>


### PR DESCRIPTION
My original plan was to change the arrow color for animals that have multiple images. However, I ran into a problem. The bootstrap code for the arrows does not allow me to change the color. The arrows are actually icons, which made changing the colors impossible. 

Instead, I implemented indicators for animals that have multiple images. The indicators are in the same color as the headers. The odd thing is that the header color in the indicators created an illusion that it is white when it is in front of colors that are muted like grey, light brown etc. To combat this, I increased the intensity of the border color to a brighter blueish color so that indicators will 'look' the same color as the headers.    

![pull request](https://github.com/senior-eng-project/Animal-Dating-App/assets/13703308/abf19428-3608-4bb6-91c2-ed3874d4a450)