### PR TITLE
Add Image Previews to Messages

### DIFF
--- a/src/components/Cards/AnimalGalleryCard.js
+++ b/src/components/Cards/AnimalGalleryCard.js
@@ -83,7 +83,7 @@ const AnimalGalleryCard = ({
     let type = animal.type ? animal.type.toLowerCase() : "other";
     let placeholder = placeholderImages[type] || placeholderImages.other;
 
-    let uri = typeof animal.pictureUri === "string" ? animal.pictureUri : animal.pictureUri[0];
+    let uri = Array.isArray(animal.pictureUri) ? animal.pictureUri[0] : animal.pictureUri;
 
     // If image fails to load, fallback to placeholder
     if (uri) {

--- a/src/components/Cards/AnimalGalleryCard.js
+++ b/src/components/Cards/AnimalGalleryCard.js
@@ -83,7 +83,7 @@ const AnimalGalleryCard = ({
     let type = animal.type ? animal.type.toLowerCase() : "other";
     let placeholder = placeholderImages[type] || placeholderImages.other;
 
-    let uri = animal.pictureUri;
+    let uri = typeof animal.pictureUri === "string" ? animal.pictureUri : animal.pictureUri[0];
 
     // If image fails to load, fallback to placeholder
     if (uri) {

--- a/src/components/Cards/ChatMessagesCard.js
+++ b/src/components/Cards/ChatMessagesCard.js
@@ -213,9 +213,9 @@ function ChatMessagesCard() {
                       { pet.pictureUri && testImageSrc(pet.pictureUri) && (
                         <div className="col-2">
                           {typeof pet.pictureUri === 'string' ?
-                            <img src={pet.pictureUri} className="img-fluid rounded-start" alt="Pet Profile" />
+                            <img src={pet.pictureUri} className="h-100 img-fluid rounded-start" alt="Pet Profile" />
                             :
-                            <img src={pet.pictureUri[0]} className="img-fluid rounded-start" alt="Pet Profile" />
+                            <img src={pet.pictureUri[0]} className="h-100 img-fluid rounded-start" alt="Pet Profile" />
                           }
                         </div>
                       )}

--- a/src/components/Cards/ChatMessagesCard.js
+++ b/src/components/Cards/ChatMessagesCard.js
@@ -91,7 +91,7 @@ function ChatMessagesCard() {
       toName: chats[selectedChat].user.name,
       date: new Date(),
       content: inputMessage,
-      pet: pet || undefined,
+      pet: pet || null,
       read: false
     };
   

--- a/src/components/Cards/ChatMessagesCard.js
+++ b/src/components/Cards/ChatMessagesCard.js
@@ -104,9 +104,20 @@ function ChatMessagesCard() {
     }
   };
 
-  const removePetAttachment = () => {
-    setPet(null);
-  };
+  const testImageSrc = (pictureUri) => {
+    let src = pictureUri;
+
+    if (typeof pictureUri !== 'string') {
+      src = pictureUri[0];
+    }
+
+    return new Promise((resolve, reject) => {
+      const img = new Image();
+      img.onload = () => resolve(true);
+      img.onerror = () => resolve(false);
+      img.src = src;
+    });
+  }
 
   useEffect(() => {
     if (!selectedChat) return;
@@ -164,13 +175,26 @@ function ChatMessagesCard() {
               <h5 className="pb-2">{chats[selectedChat].user.name || 'Anonymous User'}</h5>
               <div style={{ overflowY: 'auto', height: '70vh' }} ref={messagesContainerRef}>
                 {chats[selectedChat].messages.length > 0 ? chats[selectedChat].messages.map((msg, index) => (
-                  <div key={index} style={{ textAlign: msg.fromId === currentUserId ? 'right' : 'left' }} className="mb-2">
+                  <div key={index} style={{ textAlign: msg.fromId === currentUserId ? 'right' : 'left', cursor: 'pointer' }} className="mb-2" onClick={() => msg.pet && navigate('/pet', { state: { pet: msg.pet } })}>
                     {msg.pet && (
                       <>
-                      <div className="mb-2" style={{ backgroundColor: msg.fromId === currentUserId ? '#DDECEA' : 'grey', color: msg.fromId === currentUserId ? 'black' : 'white', display: 'inline-block', padding: '5px 15px', borderRadius: '10px' }}>
-                        <div className="small p-1" style={{ color: msg.fromId === currentUserId ? 'grey' : 'white' }}>Attached Pet: <button className="btn btn-link" onClick={() => navigate('/pet', { state: { pet: msg.pet } })}
-                        style={{ color: msg.fromId === currentUserId ? 'blue' : 'white' }}
-                        >{msg.pet.name}</button></div>
+                      <div className="mb-2 p-0" style={{ backgroundColor: msg.fromId === currentUserId ? '#DDECEA' : 'grey', color: msg.fromId === currentUserId ? 'black' : 'white', display: 'inline-block', padding: '5px 15px', borderRadius: '10px' }}>
+                        <div className="row g-0" style={{ maxWidth: '250px' }}>
+                        { msg.pet.pictureUri && testImageSrc(msg.pet.pictureUri) && (
+                            <div className="col-6">
+                              {
+                            typeof msg.pet.pictureUri === 'string' ?
+                              <img src={msg.pet.pictureUri} className="img-fluid rounded-start" alt="Pet Profile" />
+                              :
+                              <img src={msg.pet.pictureUri[0]} className="img-fluid rounded-start" alt="Pet Profile" />
+                          }
+                            </div>
+                          ) }
+
+                        <div className={`small col-${msg.pet.pictureUri && testImageSrc(msg.pet.pictureUri) ? '6' : '12'}`} style={{ color: msg.fromId === currentUserId ? 'grey' : 'white' }}>
+                          <div className="h-100 p-3 d-flex flex-wrap text-center align-items-center justify-content-center">Attached Pet: <span className="text-black fw-bold">{msg.pet.name}</span></div>
+                          </div>
+                        </div>
                     </div>
                     <br/>
                     </>
@@ -184,13 +208,30 @@ function ChatMessagesCard() {
               </div>
               {pet && (
                 <Card className="mb-2">
-                  <Card.Body className="d-flex justify-content-between align-items-center">
-                    <div>
-                      Attached Pet: <button className="btn btn-link" onClick={() => navigate('/pet', { state: { pet } })}>{pet.name}</button>
+                  <Card.Body className="d-flex justify-content-between align-items-center p-0">
+                    <div className="row g-0">
+                      { pet.pictureUri && testImageSrc(pet.pictureUri) && (
+                        <div className="col-2">
+                          {typeof pet.pictureUri === 'string' ?
+                            <img src={pet.pictureUri} className="img-fluid rounded-start" alt="Pet Profile" />
+                            :
+                            <img src={pet.pictureUri[0]} className="img-fluid rounded-start" alt="Pet Profile" />
+                          }
+                        </div>
+                      )}
+                      <div className={`col-${pet.pictureUri && testImageSrc(pet.pictureUri) ? '9' : '10'}`}>
+                        <div className="h-100 p-3 d-flex flex-wrap text-center align-items-center justify-content-center">
+                        Attached Pet: <button className="btn btn-link" onClick={() => navigate('/pet', { state: { pet } })}>{pet.name}</button>
+                        </div>
+                      </div>
+                      <div className="col-1">
+                        <div className="h-100 p-3 d-flex flex-wrap text-center align-items-center justify-content-center">
+                          <Button variant="outline-danger" size="sm" onClick={() => setPet(null)}>
+                            <FontAwesomeIcon icon={faTimes} />
+                          </Button>
+                        </div>
+                        </div>
                     </div>
-                    <Button variant="outline-danger" size="sm" onClick={removePetAttachment}>
-                      <FontAwesomeIcon icon={faTimes} />
-                    </Button>
                   </Card.Body>
                 </Card>
               )}

--- a/src/components/Cards/ChatMessagesCard.js
+++ b/src/components/Cards/ChatMessagesCard.js
@@ -107,7 +107,7 @@ function ChatMessagesCard() {
   const testImageSrc = (pictureUri) => {
     let src = pictureUri;
 
-    if (typeof pictureUri !== 'string') {
+    if (Array.isArray(pictureUri)) {
       src = pictureUri[0];
     }
 
@@ -183,11 +183,11 @@ function ChatMessagesCard() {
                         { msg.pet.pictureUri && testImageSrc(msg.pet.pictureUri) && (
                             <div className="col-6">
                               {
-                            typeof msg.pet.pictureUri === 'string' ?
-                              <img src={msg.pet.pictureUri} className="img-fluid rounded-start" alt="Pet Profile" />
-                              :
-                              <img src={msg.pet.pictureUri[0]} className="img-fluid rounded-start" alt="Pet Profile" />
-                          }
+                                Array.isArray(msg.pet.pictureUri) ?
+                                  <img src={msg.pet.pictureUri[0]} className="img-fluid rounded-start" alt="Pet Profile" />
+                                  :
+                                  <img src={msg.pet.pictureUri} className="img-fluid rounded-start" alt="Pet Profile" />
+                              }
                             </div>
                           ) }
 
@@ -212,10 +212,11 @@ function ChatMessagesCard() {
                     <div className="row g-0">
                       { pet.pictureUri && testImageSrc(pet.pictureUri) && (
                         <div className="col-2">
-                          {typeof pet.pictureUri === 'string' ?
-                            <img src={pet.pictureUri} className="h-100 img-fluid rounded-start" alt="Pet Profile" />
-                            :
+                          {Array.isArray(pet.pictureUri) ?
                             <img src={pet.pictureUri[0]} className="h-100 img-fluid rounded-start" alt="Pet Profile" />
+                            :
+                            <img src={pet.pictureUri} className="h-100 img-fluid rounded-start" alt="Pet Profile" />
+                            
                           }
                         </div>
                       )}


### PR DESCRIPTION
This PR refactors the pet "attachment" in conversations to show an image preview of the attached pet rather than just the pet name.

It appears like so when sent in a conversation:
<img width="272" alt="Screenshot 2024-04-24 at 10 08 13 PM" src="https://github.com/senior-eng-project/Animal-Dating-App/assets/13807630/63688393-216a-4c20-86c8-d15615f2dae9">

And like so when composing a message:
<img width="610" alt="Screenshot 2024-04-24 at 10 08 37 PM" src="https://github.com/senior-eng-project/Animal-Dating-App/assets/13807630/e038a924-c1bd-40c6-aa65-4621172c07a5">
